### PR TITLE
fix: Add function names for anonymous react components

### DIFF
--- a/src/components/elements/Footer/Footer.jsx
+++ b/src/components/elements/Footer/Footer.jsx
@@ -1,4 +1,4 @@
-export default function () {
+export default function Footer() {
   return (
     <footer className="text-xs text-center py-2 border-t">
       <p>

--- a/src/components/elements/Header/Header.jsx
+++ b/src/components/elements/Header/Header.jsx
@@ -5,7 +5,7 @@ import IconLogout from "@/components/icons/Logout";
 import { Nunito } from "next/font/google";
 const nunito = Nunito({ subsets: ["latin"] });
 
-export default function () {
+export default function Header() {
   return (
     <>
       <Head>

--- a/src/components/elements/TalkFooter/TalkFooter.jsx
+++ b/src/components/elements/TalkFooter/TalkFooter.jsx
@@ -6,7 +6,7 @@ import styles from "./TalkFooter.module.css";
 const nunito = Nunito({ subsets: ["latin"] });
 const openSans = Open_Sans({ subsets: ["latin"] });
 
-export default function ({ talk }) {
+export default function TalkFooter({ talk }) {
   return (
     <footer
       className={`${styles.card__footer} justify-between flex gap-8 ${openSans.className}`}

--- a/src/components/icons/PadLock.jsx
+++ b/src/components/icons/PadLock.jsx
@@ -1,4 +1,4 @@
-export default function ({ width }) {
+export default function PadLock({ width }) {
   return (
     <svg
       width={width}


### PR DESCRIPTION
When creating a production build I had to add explicit function names to the exported functions to stop next from complaining.